### PR TITLE
Selinux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - .:/var/www/html:Z
       - caddy_data:/data
       - caddy_config:/config
-      - ./docker/Caddyfile:/etc/frankenphp/Caddyfile:Z
+      - ./docker/Caddyfile:/etc/frankenphp/Caddyfile
     tty: true
     environment:
       APP_RUNTIME: "Runtime\\FrankenPhpSymfony\\Runtime"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8088:80"
     volumes:
-      - .:/var/www/html
+      - .:/var/www/html:Z
       - ./docker/fpm.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
     networks:
       - app-net
@@ -21,7 +21,7 @@ services:
       - "443:443/udp"
       - "2019:2019"
     volumes:
-      - .:/var/www/html
+      - .:/var/www/html:Z
       - ./docker/Caddyfile.regular:/etc/frankenphp/Caddyfile
     tty: true
     environment:
@@ -38,10 +38,10 @@ services:
       - "444:443/udp"
       - "2020:2019"
     volumes:
-      - .:/var/www/html
+      - .:/var/www/html:Z
       - caddy_data:/data
       - caddy_config:/config
-      - ./docker/Caddyfile:/etc/frankenphp/Caddyfile
+      - ./docker/Caddyfile:/etc/frankenphp/Caddyfile:Z
     tty: true
     environment:
       APP_RUNTIME: "Runtime\\FrankenPhpSymfony\\Runtime"


### PR DESCRIPTION
When running the "make up" on Fedora Linux, the app container had no write permissions to do things. 
With Fedora, you have SELINUX and thus need to relabel the volumes.

This PR should fix that.

I did not check if *all* the containers need that.